### PR TITLE
Remove unreachable HEAD method comparison in ApiTryIt

### DIFF
--- a/components/portal/api-try-it.tsx
+++ b/components/portal/api-try-it.tsx
@@ -90,7 +90,6 @@ export function ApiTryIt({
     if (
       bodyValue &&
       method !== "GET" &&
-      method !== "HEAD" &&
       method !== "DELETE"
     ) {
       lines.push(`     -H "Content-Type: application/json"`);
@@ -112,7 +111,6 @@ export function ApiTryIt({
       if (
         bodyValue &&
         method !== "GET" &&
-        method !== "HEAD" &&
         method !== "DELETE"
       ) {
         fetchOptions.body = bodyValue;


### PR DESCRIPTION
Fixes #4.

Drops two unreachable `method !== "HEAD"` checks in `components/portal/api-try-it.tsx`.
The `method` prop's type already excludes `"HEAD"`, so both `if` blocks evaluate identically after removal — no runtime behavior change. `npx tsc --noEmit` now exits 0.