### PR TITLE
Fix required-field mismatches in Request Translation docs

### DIFF
--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -927,7 +927,6 @@ export const dubbingCategory: ApiCategory = {
             name: "numberOfSpeakers",
             type: "integer",
             required: true,
-            default: "1",
             description:
               "Number of speakers in the video for multi-speaker detection.",
           },
@@ -959,7 +958,7 @@ export const dubbingCategory: ApiCategory = {
           {
             name: "ttsModel",
             type: "string",
-            required: false,
+            required: true,
             description:
               "TTS model selection. ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
             enum: ["ELEVEN_V2", "ELEVEN_V3"],
@@ -980,6 +979,7 @@ export const dubbingCategory: ApiCategory = {
   "numberOfSpeakers": 2,
   "withLipSync": false,
   "preferredSpeedType": "GREEN",
+  "ttsModel": "ELEVEN_V2",
   "title": "My Translation Project"
 }`,
       },


### PR DESCRIPTION
## Summary
- `ttsModel`: `required: false` → `true`. Backend rejects requests omitting it with `400 VT4001 "must not be null"`.
- `numberOfSpeakers`: drop the misleading `default: "1"`. Backend does not apply any default — omitting the field also yields the null violation.
- Request example: add `"ttsModel": "ELEVEN_V2"` so a copy-paste call succeeds.

Fixes #6.

Doc data only — no runtime behavior change.

## Test plan
- [x] After the change, `/llms.txt` renders `ttsModel (string, required)` and `numberOfSpeakers` without the default annotation.
- [x] Confirmed the corrected example payload returns `201` from `https://api.perso.ai`; baseline 400 reproduction in #6.
