### PR TITLE
Update create-dubbing-project API reference

### DIFF
--- a/components/portal/api-endpoint.tsx
+++ b/components/portal/api-endpoint.tsx
@@ -38,7 +38,7 @@ export function ApiToc({ items }: { items: TocItem[] }) {
           setActiveId(visible[0].target.id);
         }
       },
-      { rootMargin: "-20% 0px -60% 0px", threshold: 0 }
+      { rootMargin: "-20% 0px -60% 0px", threshold: 0 },
     );
 
     elements.forEach((el) => observer.observe(el));
@@ -58,7 +58,7 @@ export function ApiToc({ items }: { items: TocItem[] }) {
               "h-1 rounded-full transition-all duration-200",
               activeId === item.id
                 ? cn("w-7 opacity-100", tocBarColors[item.method])
-                : cn("w-5 opacity-40", tocBarColors[item.method])
+                : cn("w-5 opacity-40", tocBarColors[item.method]),
             )}
           />
         ))}
@@ -77,13 +77,13 @@ export function ApiToc({ items }: { items: TocItem[] }) {
                 href={`#${item.id}`}
                 className={cn(
                   "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-secondary/60 group",
-                  activeId === item.id && "bg-secondary/80"
+                  activeId === item.id && "bg-secondary/80",
                 )}
               >
                 <Badge
                   className={cn(
                     "font-mono text-[10px] px-1 w-12 justify-center shrink-0",
-                    methodColors[item.method]
+                    methodColors[item.method],
                   )}
                 >
                   {item.method}
@@ -93,7 +93,7 @@ export function ApiToc({ items }: { items: TocItem[] }) {
                     "font-medium text-xs group-hover:text-primary whitespace-nowrap",
                     activeId === item.id
                       ? "text-primary font-semibold"
-                      : "text-foreground"
+                      : "text-foreground",
                   )}
                 >
                   {item.title}
@@ -104,7 +104,7 @@ export function ApiToc({ items }: { items: TocItem[] }) {
         </div>
       </div>
     </div>,
-    document.body
+    document.body,
   );
 }
 
@@ -131,6 +131,8 @@ export interface Parameter {
   description: string;
   default?: string;
   enum?: string[];
+  deprecated?: boolean;
+  fields?: Parameter[];
 }
 
 export interface ErrorResponse {

--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -386,8 +386,7 @@ export const fileCategory: ApiCategory = {
             name: "url",
             type: "string",
             required: true,
-            description:
-              "External video URL (YouTube, TikTok, Google Drive).",
+            description: "External video URL (YouTube, TikTok, Google Drive).",
           },
           {
             name: "lang",
@@ -645,8 +644,7 @@ export const fileCategory: ApiCategory = {
             name: "url",
             type: "string",
             required: true,
-            description:
-              "External video URL (YouTube, TikTok, Google Drive).",
+            description: "External video URL (YouTube, TikTok, Google Drive).",
           },
           {
             name: "lang",
@@ -884,7 +882,8 @@ export const dubbingCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/translate",
       title: "Request Translation",
       description:
-        "Submit a video or audio translation request based on uploaded media files. The mediaSeq is the seq value returned from the Upload Video or Upload Audio endpoint in the File API. If you receive a 'space queue not found' error, you must first call the PUT /api/v1/projects/spaces/{spaceSeq}/queue endpoint (Usage API) to initialize the queue before retrying.",
+        "Submit a video or audio translation request based on uploaded media files. The mediaSeq is the seq value returned from the Upload Video or Upload Audio endpoint in the File API. New integrations should use `targetLanguages` (per-language TTS model selection). The legacy `targetLanguageCodes` + `ttsModel` pair is still accepted for backward compatibility, but is deprecated. " +
+        "If you receive a 'space queue not found' error, you must first call the PUT /api/v1/projects/spaces/{spaceSeq}/queue endpoint (Usage API) to initialize the queue before retrying.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -919,14 +918,44 @@ export const dubbingCategory: ApiCategory = {
           {
             name: "targetLanguageCodes",
             type: "string[]",
-            required: true,
+            required: false,
             description:
-              "Array of target language codes to translate into.",
+              "(Deprecated since 2026-05-22) Array of target language codes to translate into. " +
+              "New integrations should use `targetLanguages` instead. " +
+              "If both fields are provided, `targetLanguages` takes precedence. " +
+              "Either `targetLanguageCodes` or `targetLanguages` must be provided.",
+          },
+          {
+            name: "targetLanguages",
+            type: "object[]",
+            required: false,
+            description:
+              "Recommended. List of target language and TTS model pairs. " +
+              "When provided, this field takes precedence over `targetLanguageCodes` and the top-level `ttsModel`. " +
+              "Either `targetLanguageCodes` or `targetLanguages` must be provided.",
+            fields: [
+              {
+                name: "languageCode",
+                type: "string",
+                required: true,
+                description:
+                  "Target language code (e.g. 'en', 'ko'). Must be a valid code returned by the Language API.",
+              },
+              {
+                name: "ttsModel",
+                type: "string",
+                required: false,
+                enum: ["ELEVEN_V2", "ELEVEN_V3"],
+                description:
+                  "TTS model to apply to this language. Required for DUBBING / LIPSYNC requests. " +
+                  "Ignored for STT / AudioSeparation requests (may be omitted).",
+              },
+            ],
           },
           {
             name: "numberOfSpeakers",
             type: "integer",
-            required: true,
+            required: false,
             default: "1",
             description:
               "Number of speakers in the video for multi-speaker detection.",
@@ -960,6 +989,7 @@ export const dubbingCategory: ApiCategory = {
             name: "ttsModel",
             type: "string",
             required: false,
+            deprecated: true,
             description:
               "TTS model selection. ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
             enum: ["ELEVEN_V2", "ELEVEN_V3"],
@@ -976,7 +1006,10 @@ export const dubbingCategory: ApiCategory = {
   "mediaSeq": 12345,
   "isVideoProject": true,
   "sourceLanguageCode": "en",
-  "targetLanguageCodes": ["ko", "ja"],
+  "targetLanguages": [
+      { "languageCode": "ko", "ttsModel": "ELEVEN_V3" },
+      { "languageCode": "ja", "ttsModel": "ELEVEN_V2" }
+  ],
   "numberOfSpeakers": 2,
   "withLipSync": false,
   "preferredSpeedType": "GREEN",
@@ -1008,6 +1041,11 @@ export const dubbingCategory: ApiCategory = {
           code: "VT4021",
           status: 402,
           description: "Insufficient credits",
+        },
+        {
+          code: "VT4009",
+          status: 400,
+          description: "Target language and TTS model pair is not supported",
         },
       ],
     },
@@ -1360,8 +1398,7 @@ export const dubbingCategory: ApiCategory = {
           name: "sharedStatus",
           type: "boolean",
           required: true,
-          description:
-            "Whether to enable (true) or disable (false) sharing.",
+          description: "Whether to enable (true) or disable (false) sharing.",
         },
       ],
       response: {
@@ -1488,8 +1525,7 @@ export const dubbingCategory: ApiCategory = {
       method: "GET",
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/retranslation/status",
       title: "Check Retranslation Status",
-      description:
-        "Check whether retranslation is available for a project.",
+      description: "Check whether retranslation is available for a project.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1583,8 +1619,7 @@ export const editingCategory: ApiCategory = {
             name: "targetText",
             type: "string",
             required: true,
-            description:
-              "The text to translate or the updated translation.",
+            description: "The text to translate or the updated translation.",
           },
         ],
         example: `{
@@ -1618,8 +1653,7 @@ export const editingCategory: ApiCategory = {
       method: "PATCH",
       path: "/video-translator/api/v1/project/{projectSeq}/audio-sentence/{audioSentenceSeq}/generate-audio",
       title: "Generate Audio",
-      description:
-        "Generate a translated audio file for a specific sentence.",
+      description: "Generate a translated audio file for a specific sentence.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1675,8 +1709,7 @@ export const editingCategory: ApiCategory = {
       method: "PUT",
       path: "/video-translator/api/v1/project/{projectSeq}/audio-sentence/{audioSentenceSeq}/reset",
       title: "Reset Translation",
-      description:
-        "Reset a translation back to its original proofread state.",
+      description: "Reset a translation back to its original proofread state.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1707,8 +1740,7 @@ export const editingCategory: ApiCategory = {
       method: "PUT",
       path: "/video-translator/api/v1/project/{projectSeq}/audio-sentence/{audioSentenceSeq}/cancel",
       title: "Cancel Translation",
-      description:
-        "Cancel an in-progress translation for a specific sentence.",
+      description: "Cancel an in-progress translation for a specific sentence.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1859,15 +1891,13 @@ export const editingCategory: ApiCategory = {
             name: "isLipSync",
             type: "boolean",
             required: false,
-            description:
-              "Whether to enable lip sync for the proofread output.",
+            description: "Whether to enable lip sync for the proofread output.",
           },
           {
             name: "experimentKey",
             type: "string",
             required: false,
-            description:
-              "Experiment key for A/B testing configurations.",
+            description: "Experiment key for A/B testing configurations.",
           },
           {
             name: "preferredSpeedType",
@@ -2325,8 +2355,7 @@ export const languageCategory: ApiCategory = {
 export const feedbackCategory: ApiCategory = {
   slug: "feedback",
   title: "Feedback API",
-  description:
-    "Submit and retrieve feedback ratings for translated projects.",
+  description: "Submit and retrieve feedback ratings for translated projects.",
   endpoints: [
     {
       id: "submit-feedback",
@@ -2414,8 +2443,7 @@ export const feedbackCategory: ApiCategory = {
 export const communitySpotlightCategory: ApiCategory = {
   slug: "community-spotlight",
   title: "Community Spotlight API",
-  description:
-    "Browse featured public projects and shared translations.",
+  description: "Browse featured public projects and shared translations.",
   endpoints: [
     {
       id: "list-recommended",
@@ -2442,8 +2470,7 @@ export const communitySpotlightCategory: ApiCategory = {
           name: "languageCode",
           type: "string",
           required: false,
-          description:
-            "Filter by target language code (e.g. ko, en, ja).",
+          description: "Filter by target language code (e.g. ko, en, ja).",
         },
       ],
       response: {

--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -883,7 +883,7 @@ export const dubbingCategory: ApiCategory = {
       title: "Request Translation",
       description:
         "Submit a video or audio translation request based on uploaded media files. The mediaSeq is the seq value returned from the Upload Video or Upload Audio endpoint in the File API. New integrations should use `targetLanguages` (per-language TTS model selection). The legacy `targetLanguageCodes` + `ttsModel` pair is still accepted for backward compatibility, but is deprecated. " +
-        "If you receive a 'space queue not found' error, you must first call the PUT /api/v1/projects/spaces/{spaceSeq}/queue endpoint (Usage API) to initialize the queue before retrying.",
+        "If you receive a 'space queue not found' error, you must first call the PUT /video-translator/api/v1/projects/spaces/{spaceSeq}/queue endpoint (Usage API) to initialize the queue before retrying.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -991,7 +991,9 @@ export const dubbingCategory: ApiCategory = {
             required: false,
             deprecated: true,
             description:
-              "TTS model selection. ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
+              "(Deprecated since 2026-05-22) Single TTS model applied to all target languages. " +
+              "New integrations should specify `ttsModel` per language inside `targetLanguages`. " +
+              "ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
             enum: ["ELEVEN_V2", "ELEVEN_V3"],
           },
           {

--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -991,7 +991,7 @@ export const dubbingCategory: ApiCategory = {
             required: false,
             deprecated: true,
             description:
-              "(Deprecated since 2026-05-22) Single TTS model applied to all target languages. " +
+              "(Deprecated since 2026-05-14) Single TTS model applied to all target languages. " +
               "New integrations should specify `ttsModel` per language inside `targetLanguages`. " +
               "ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
             enum: ["ELEVEN_V2", "ELEVEN_V3"],

--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -920,7 +920,7 @@ export const dubbingCategory: ApiCategory = {
             type: "string[]",
             required: false,
             description:
-              "(Deprecated since 2026-05-22) Array of target language codes to translate into. " +
+              "(Deprecated since 2026-05-14) Array of target language codes to translate into. " +
               "New integrations should use `targetLanguages` instead. " +
               "If both fields are provided, `targetLanguages` takes precedence. " +
               "Either `targetLanguageCodes` or `targetLanguages` must be provided.",


### PR DESCRIPTION
## Summary

- Update API docs data to replace deprecated request fields and add newly supported parameter fields for the create-dubbing-project endpoint
- Add parameter metadata to improve the rendered API reference
- Minor adjustment in `components/portal/api-endpoint.tsx` to align with the updated data shape

## Related issues

<!-- Closes #123 / Fixes #123 / Refs #123 -->

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling
- [ ] Other (describe below)

## Screenshots / recordings

N/A — docs data only.

## Test plan

- [x] Verified the updated fields render correctly on the API docs page locally
- [ ] `pnpm lint` passes
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] `pnpm build` passes
- [ ] Manually tested locally

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No API keys, tokens, or other secrets are included in this PR
- [x] Changes are scoped to a single logical concern
- [x] Documentation is updated if behavior changed