### PR TITLE
chore: make AI agent banner non-dismissible

### DIFF
--- a/components/portal/ai-agent-banner.tsx
+++ b/components/portal/ai-agent-banner.tsx
@@ -1,32 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Bot, Copy, Check, X } from "lucide-react";
+import { useState } from "react";
+import { Bot, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const LLM_URL = "https://developers.perso.ai/llms.txt";
-const DISMISS_KEY = "ai-agent-banner-dismissed";
 
 export function AiAgentBanner() {
-  const [dismissed, setDismissed] = useState(true);
   const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    const v = typeof window !== "undefined" ? localStorage.getItem(DISMISS_KEY) : null;
-    if (v !== "1") setDismissed(false);
-  }, []);
-
-  if (dismissed) return null;
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(LLM_URL);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  };
-
-  const handleDismiss = () => {
-    localStorage.setItem(DISMISS_KEY, "1");
-    setDismissed(true);
   };
 
   return (
@@ -66,13 +52,6 @@ export function AiAgentBanner() {
             </Button>
           </div>
         </div>
-        <button
-          onClick={handleDismiss}
-          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"
-          aria-label="Dismiss"
-        >
-          <X className="h-4 w-4" />
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## 개요
`AiAgentBanner`(llms.txt 안내 배너)를 사용자가 닫을 수 없도록 변경합니다. ✕ 닫기 버튼과 관련 dismiss 로직을 제거해, `/docs`·`/overview` 페이지에서 배너가 항상 표시됩니다.

## 변경 내용
`components/portal/ai-agent-banner.tsx`:
- ✕ 닫기 버튼 JSX 제거
- `handleDismiss` 함수 및 `dismissed` 상태 제거
- localStorage 기반 dismiss 영속화 제거 (`DISMISS_KEY`)
- `if (dismissed) return null;` 조기 반환 제거
- 미사용이 된 import 정리 (`X` 아이콘, `useEffect`)

Copy URL 버튼 등 나머지 기능은 그대로 유지됩니다.

## 동작 확인
- 로컬 dev 서버에서 `/docs` 페이지 렌더링 확인
- 배너가 상단에 항상 표시되고 ✕ 버튼이 사라진 것을 확인
- 서버 렌더 HTML에 배너 문구 포함, `aria-label="Dismiss"` 미존재 확인