### PR TITLE
Feature/change banner location

### DIFF
--- a/components/portal/sidebar.tsx
+++ b/components/portal/sidebar.tsx
@@ -76,7 +76,7 @@ export function Sidebar({ mobile, onNavigate }: SidebarProps = {}) {
       !mobile && "fixed left-0 top-0 z-40"
     )}>
       <div className="flex h-16 items-center gap-2 border-b border-border px-6">
-        <a href={serviceUrl || "#"} className="cursor-pointer">
+        <a href={serviceUrl ? `${serviceUrl}/workspace` : "#"} className="cursor-pointer">
           <img
             decoding="auto"
             width="129"


### PR DESCRIPTION
## Summary

Sidebar logo now links to the workspace page (`${serviceUrl}/workspace`) instead of the service root, so clicking the logo takes users directly to their workspace. Also makes the AI agent banner non-dismissible by removing the dismiss button and its `localStorage`-backed state.

## Related issues

<!-- Closes #123 / Fixes #123 / Refs #123 -->

## Type of change

- [] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Other (describe below)

## Screenshots / recordings

<!-- For UI changes, attach before/after screenshots or a short clip. -->

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] `pnpm build` passes
- [x] Manually tested locally
  - Clicked the sidebar logo and confirmed it navigates to `/workspace`.
  - Verified the AI agent banner no longer shows a dismiss (X) button and stays visible after reload.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No API keys, tokens, or other secrets are included in this PR
- [x] Changes are scoped to a single logical concern
- [ ] Documentation is updated if behavior changed
