### PR TITLE
feat: show user profile instead of plan/credit in GNB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ coverage/
 *.log
 *.local
 /.next/
+
+# Local HTTPS dev certificates (next dev --experimental-https)
+/certificates/

--- a/app/(portal)/layout.tsx
+++ b/app/(portal)/layout.tsx
@@ -16,8 +16,7 @@ function getPageTitle(pathname: string): string {
 
 function PortalShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { spaceInfo, creditBalance, authFailed, sidebarOpen, setSidebarOpen } =
-    usePortal();
+  const { userProfile, authFailed, sidebarOpen, setSidebarOpen } = usePortal();
   const title = getPageTitle(pathname);
 
   return (
@@ -34,8 +33,7 @@ function PortalShell({ children }: { children: React.ReactNode }) {
         <Header
           title={title}
           authFailed={authFailed}
-          spaceInfo={spaceInfo}
-          creditBalance={creditBalance}
+          userProfile={userProfile}
           onMenuClick={() => setSidebarOpen(true)}
         />
         <main className="p-4 sm:p-6">{children}</main>

--- a/components/portal/header.tsx
+++ b/components/portal/header.tsx
@@ -8,18 +8,21 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { ApiSearch } from "@/components/portal/api-search";
 import { getConfig } from "@/lib/api";
-import type { SpaceInfo, CreditBalance } from "@/lib/api";
+import type { UserProfile } from "@/lib/api";
 
 interface HeaderProps {
   title: string;
   description?: string;
   authFailed?: boolean;
-  spaceInfo?: SpaceInfo | null;
-  creditBalance?: CreditBalance | null;
+  userProfile?: UserProfile | null;
   onMenuClick?: () => void;
 }
 
-export function Header({ title, description, authFailed, spaceInfo, creditBalance, onMenuClick }: HeaderProps) {
+function getDisplayName(profile: UserProfile): string {
+  return profile.userName || profile.email || "";
+}
+
+export function Header({ title, description, authFailed, userProfile, onMenuClick }: HeaderProps) {
   const [loginLink, setLoginLink] = useState("");
   const [isLocal, setIsLocal] = useState(false);
   const [token, setToken] = useState("");
@@ -126,7 +129,7 @@ export function Header({ title, description, authFailed, spaceInfo, creditBalanc
           </>
         )}
 
-        {/* Auth state: login button or plan/credit info */}
+        {/* Auth state: login button or user name */}
         {authFailed ? (
           loginLink && (
             <a
@@ -138,21 +141,19 @@ export function Header({ title, description, authFailed, spaceInfo, creditBalanc
             </a>
           )
         ) : (
-          <>
-            <Separator orientation="vertical" className="h-6" />
-            <div className="hidden sm:flex flex-col items-end px-3 py-1">
-              {spaceInfo && (
-                <span className="text-sm font-bold text-foreground leading-tight">
-                  {spaceInfo.planName}
+          userProfile && (
+            <>
+              <Separator orientation="vertical" className="hidden sm:block h-6" />
+              <div className="hidden sm:flex items-center gap-2">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                  {getDisplayName(userProfile).charAt(0).toUpperCase()}
                 </span>
-              )}
-              {creditBalance && (
-                <span className="text-xs text-muted-foreground leading-tight">
-                  {creditBalance.credit.toLocaleString()} credits
+                <span className="max-w-40 truncate text-sm font-medium text-foreground">
+                  {getDisplayName(userProfile)}
                 </span>
-              )}
-            </div>
-          </>
+              </div>
+            </>
+          )
         )}
       </div>
     </header>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -209,6 +209,13 @@ async function apiRequest<T>(
   return response.json();
 }
 
+// 유저 프로필 타입
+export interface UserProfile {
+  userSeq: number;
+  userName?: string;
+  email?: string;
+}
+
 // 스페이스 정보 타입
 export interface SpaceInfo {
   spaceSeq: number;
@@ -265,6 +272,13 @@ export interface CreditHistoryPage {
   number: number;
   numberOfElements: number;
 }
+
+// 유저 API
+export const userApi = {
+  // 내 프로필 조회
+  getProfile: () =>
+    apiRequest<ApiResponse<UserProfile>>("/user/api/v1/users/profile"),
+};
 
 // 스페이스 API
 export const spaceApi = {

--- a/lib/portal-context.tsx
+++ b/lib/portal-context.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect } from "react";
-import { spaceApi, creditApi } from "@/lib/api";
-import type { SpaceInfo, CreditBalance } from "@/lib/api";
+import { userApi } from "@/lib/api";
+import type { UserProfile } from "@/lib/api";
 
 interface PortalContextValue {
-  spaceInfo: SpaceInfo | null;
-  creditBalance: CreditBalance | null;
+  userProfile: UserProfile | null;
   authFailed: boolean;
   sidebarOpen: boolean;
   setSidebarOpen: (open: boolean) => void;
@@ -16,22 +15,14 @@ const PortalContext = createContext<PortalContextValue | null>(null);
 
 export function PortalProvider({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [spaceInfo, setSpaceInfo] = useState<SpaceInfo | null>(null);
-  const [creditBalance, setCreditBalance] = useState<CreditBalance | null>(null);
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [authFailed, setAuthFailed] = useState(false);
 
   useEffect(() => {
-    spaceApi
-      .getList()
+    userApi
+      .getProfile()
       .then((res) => {
-        const defaultSpace = res.result.find((s) => s.isDefaultSpaceOwned);
-        if (!defaultSpace) return;
-        setSpaceInfo(defaultSpace);
-
-        creditApi
-          .getBalance(defaultSpace.spaceSeq, "video_translator")
-          .then((creditRes) => setCreditBalance(creditRes.result))
-          .catch(() => {});
+        setUserProfile(res.result);
       })
       .catch(() => {
         setAuthFailed(true);
@@ -44,7 +35,7 @@ export function PortalProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <PortalContext.Provider
-      value={{ spaceInfo, creditBalance, authFailed, sidebarOpen, setSidebarOpen }}
+      value={{ userProfile, authFailed, sidebarOpen, setSidebarOpen }}
     >
       {children}
     </PortalContext.Provider>


### PR DESCRIPTION
## Summary

Replace the plan name and credit balance shown on the right side of the GNB (header) with the signed-in user's info (avatar initial + display name). The header now fetches the user profile directly instead of loading the space list and credit balance.

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Build / CI / tooling
- [ ] Other (describe below)

## Screenshots / recordings

Before: header showed plan name (e.g. "Pro") + credit balance.
After: header shows a circular avatar (first initial) + display name (`userName`, falling back to `email`). Verified in a logged-in dev session — the avatar and name render from the actual `/user/api/v1/users/profile` response.

## Test plan

- [ ] `pnpm lint` passes <!-- eslint is not installed as a dependency in this repo; the script fails with "eslint: command not found" -->
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm build` passes
- [x] Manually tested locally

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No API keys, tokens, or other secrets are included in this PR
- [x] Changes are scoped to a single logical concern
- [x] Documentation is updated if behavior changed