### PR TITLE
Release: API documentation accuracy fixes (llm.txt, portal docs, getting-started)

### DIFF
--- a/app/(connect)/connect/page.tsx
+++ b/app/(connect)/connect/page.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Copy,
+  Info,
+  KeyRound,
+  Loader2,
+  LogIn,
+  MonitorSmartphone,
+  XCircle,
+} from "lucide-react";
+import { apiKeyApi, ApiError, getConfig } from "@/lib/api";
+import type { ApiKey, ApiKeyExpirePeriod } from "@/lib/api";
+import { usePortal } from "@/lib/portal-context";
+
+// The plugin opens this page as:
+//   /connect?port=<local listener port>&name=<suggested key name>&state=<opaque echo token>
+// After the key is created it is POSTed to http://127.0.0.1:{port}/key as a text/plain
+// JSON body (text/plain keeps the request preflight-free; the listener must respond with
+// Access-Control-Allow-Origin: * so the result is readable here). Without a port param
+// the page falls back to showing the key once for manual copy.
+
+type Step = "form" | "authorizing" | "done" | "manual" | "error";
+
+const EXPIRY_LABELS: Record<ApiKeyExpirePeriod, string> = {
+  days_30: "30 days",
+  days_90: "90 days",
+  year_1: "1 year",
+  year_2: "2 years",
+};
+
+const DELIVERY_TIMEOUT_MS = 4000;
+
+// Returns false when the sign-in page could not be opened (missing loginLink or
+// config fetch failure) so callers can surface an error instead of hanging.
+async function redirectToLogin(): Promise<boolean> {
+  try {
+    const config = await getConfig();
+    if (config.loginLink) {
+      window.location.href = `${config.loginLink}/en/login?callbackUrl=${encodeURIComponent(window.location.href)}`;
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+type SocialProvider = "google" | "azure";
+
+// Pre-fetch the SSO login URL, then hand the browser to the OAuth authorization endpoint
+// with this page as the callback. redirect_uri is passed as-is (already encoded by the
+// backend); callbackUrl is encoded here.
+async function startSocialSignIn(provider: SocialProvider) {
+  try {
+    const config = await getConfig();
+    const res = await fetch(`/proxy/auth/api/v1/auth/sign-in/social?provider=${provider}`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) throw new Error(`sign-in/social ${res.status}`);
+    const data = await res.json();
+    const loginUrl = data?.result?.loginUrl;
+    if (!loginUrl || !config.apiBaseUrl) throw new Error("Missing loginUrl or apiBaseUrl");
+    window.location.href =
+      `${config.apiBaseUrl}/auth/oauth2/authorization/${provider}` +
+      `?redirect_uri=${loginUrl}&callbackUrl=${encodeURIComponent(window.location.href)}`;
+  } catch {
+    await redirectToLogin();
+  }
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 48 48" aria-hidden="true">
+      <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
+      <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
+      <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
+      <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
+    </svg>
+  );
+}
+
+function MicrosoftIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 23 23" aria-hidden="true">
+      <path fill="#F25022" d="M1 1h10v10H1z" />
+      <path fill="#7FBA00" d="M12 1h10v10H12z" />
+      <path fill="#00A4EF" d="M1 12h10v10H1z" />
+      <path fill="#FFB900" d="M12 12h10v10H12z" />
+    </svg>
+  );
+}
+
+function deliveryPayload(key: ApiKey, stateToken?: string) {
+  return JSON.stringify({
+    apiKey: key.apiKey,
+    apiKeyName: key.apiKeyName,
+    expireDate: key.expireDate,
+    ...(stateToken ? { state: stateToken } : {}),
+  });
+}
+
+async function deliverKey(port: number, body: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/key`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body,
+      signal: controller.signal,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function formatDate(dateString: string) {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function IconBadge({
+  tone,
+  children,
+}: {
+  tone: "primary" | "success" | "warning" | "destructive";
+  children: React.ReactNode;
+}) {
+  const tones = {
+    primary: "bg-primary/10 text-primary",
+    success: "bg-success/10 text-success",
+    warning: "bg-warning/10 text-warning",
+    destructive: "bg-destructive/10 text-destructive",
+  };
+  return (
+    <div className={`mb-4 flex h-11 w-11 items-center justify-center rounded-full ${tones[tone]}`}>
+      {children}
+    </div>
+  );
+}
+
+function ConnectContent() {
+  const { userProfile, authFailed } = usePortal();
+  const searchParams = useSearchParams();
+
+  const portParam = Number(searchParams.get("port"));
+  const port =
+    Number.isInteger(portParam) && portParam > 0 && portParam < 65536 ? portParam : null;
+  const stateToken = searchParams.get("state") || undefined;
+
+  const [step, setStep] = useState<Step>("form");
+  const [keyName, setKeyName] = useState(
+    () => (searchParams.get("name") || "perso-dubbing").slice(0, 16)
+  );
+  const [expiry, setExpiry] = useState<ApiKeyExpirePeriod>("year_1");
+  const [createdKey, setCreatedKey] = useState<ApiKey | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [retryFailed, setRetryFailed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const authorize = async () => {
+    setStep("authorizing");
+    try {
+      const response = await apiKeyApi.create({
+        apiKeyName: keyName || undefined,
+        expirePeriod: expiry,
+      });
+      const created = response.result;
+      setCreatedKey(created);
+
+      if (port && (await deliverKey(port, deliveryPayload(created, stateToken)))) {
+        setStep("done");
+      } else {
+        setStep("manual");
+      }
+    } catch (err) {
+      if (
+        err instanceof ApiError &&
+        (err.statusCode === 401 || err.statusCode === 403) &&
+        (await redirectToLogin())
+      ) {
+        return;
+      }
+      setErrorMessage(err instanceof ApiError ? err.message : "The authorization request failed.");
+      setStep("error");
+    }
+  };
+
+  const retryDelivery = async () => {
+    if (!port || !createdKey) return;
+    setIsRetrying(true);
+    setRetryFailed(false);
+    const delivered = await deliverKey(port, deliveryPayload(createdKey, stateToken));
+    setIsRetrying(false);
+    if (delivered) {
+      setStep("done");
+    } else {
+      setRetryFailed(true);
+    }
+  };
+
+  const copyKey = async () => {
+    if (!createdKey) return;
+    await navigator.clipboard.writeText(createdKey.apiKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const requestedBy = port && (
+    <div className="mt-5 flex items-center gap-2 border-t border-border pt-4 text-xs text-muted-foreground">
+      <MonitorSmartphone className="h-3.5 w-3.5" />
+      Requested by: perso-dubbing plugin &middot;{" "}
+      <code className="font-mono">127.0.0.1:{port}</code>
+    </div>
+  );
+
+  if (!userProfile && !authFailed) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (authFailed) {
+    return (
+      <Card className="border-border bg-card">
+        <CardContent className="p-6">
+          <IconBadge tone="primary">
+            <LogIn className="h-5 w-5" />
+          </IconBadge>
+          <h2 className="text-lg font-semibold text-foreground">
+            Connect Perso Dubbing Plugin
+          </h2>
+          <p className="mt-1 mb-5 text-sm text-muted-foreground">
+            Sign in or create an account to authorize the plugin on this device.
+          </p>
+          <div className="grid gap-2">
+            <Button
+              variant="outline"
+              className="w-full gap-2.5"
+              onClick={() => startSocialSignIn("google")}
+            >
+              <GoogleIcon />
+              Continue with Google
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full gap-2.5"
+              onClick={() => startSocialSignIn("azure")}
+            >
+              <MicrosoftIcon />
+              Continue with Microsoft
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full border-dashed text-muted-foreground"
+              onClick={() => void redirectToLogin()}
+            >
+              Continue with email
+            </Button>
+          </div>
+          {requestedBy}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === "form" || step === "authorizing") {
+    const busy = step === "authorizing";
+    return (
+      <Card className="border-border bg-card">
+        <CardContent className="p-6">
+          <IconBadge tone="primary">
+            <KeyRound className="h-5 w-5" />
+          </IconBadge>
+          <h2 className="text-lg font-semibold text-foreground">
+            Connect Perso Dubbing Plugin
+          </h2>
+          <p className="mt-1 mb-5 text-sm text-muted-foreground">
+            Authorize the plugin to use your Perso account on this device.
+          </p>
+
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="keyName">API key name</Label>
+              <Input
+                id="keyName"
+                value={keyName}
+                onChange={(e) => setKeyName(e.target.value)}
+                maxLength={16}
+                disabled={busy}
+              />
+              <p className="text-right text-xs text-muted-foreground">{keyName.length}/16</p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="expiry">Expiration</Label>
+              <Select
+                value={expiry}
+                onValueChange={(v) => setExpiry(v as ApiKeyExpirePeriod)}
+                disabled={busy}
+              >
+                <SelectTrigger id="expiry">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(EXPIRY_LABELS) as ApiKeyExpirePeriod[]).map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {EXPIRY_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="mt-4 mb-5 flex items-start gap-2 rounded-lg bg-secondary p-3 text-sm text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>
+              This key expires in <b className="text-foreground">{EXPIRY_LABELS[expiry]}</b>. When
+              it expires, the plugin will open this page again.
+            </span>
+          </div>
+
+          <Button className="w-full" onClick={authorize} disabled={busy}>
+            {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {busy ? "Authorizing…" : "Authorize plugin"}
+          </Button>
+          {requestedBy}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === "done" && createdKey) {
+    return (
+      <Card className="border-border bg-card">
+        <CardContent className="p-6">
+          <IconBadge tone="success">
+            <CheckCircle2 className="h-5 w-5" />
+          </IconBadge>
+          <h2 className="text-lg font-semibold text-foreground">Connected</h2>
+          <p className="mt-1 mb-4 text-sm text-muted-foreground">
+            Your API key has been securely delivered to the plugin.
+          </p>
+
+          <div className="mb-5 flex items-center gap-2.5 rounded-lg bg-success/10 p-3.5 text-base font-medium text-success">
+            <CheckCircle2 className="h-5 w-5 shrink-0" />
+            You can close this tab and return to your terminal.
+          </div>
+
+          <div className="divide-y divide-border rounded-lg border border-border text-sm">
+            <div className="flex items-center justify-between gap-3 px-4 py-3">
+              <span className="text-muted-foreground">Key name</span>
+              <span className="font-medium text-foreground">{createdKey.apiKeyName || "-"}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3 px-4 py-3">
+              <span className="text-muted-foreground">Expires</span>
+              <span className="font-medium text-foreground">
+                {formatDate(createdKey.expireDate)}
+              </span>
+            </div>
+          </div>
+
+          <p className="mt-4 text-xs text-muted-foreground">
+            The key value is not displayed for security. You can revoke it anytime on the API Keys
+            page.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === "manual" && createdKey) {
+    return (
+      <Card className="border-border bg-card">
+        <CardContent className="p-6">
+          <IconBadge tone="warning">
+            <AlertTriangle className="h-5 w-5" />
+          </IconBadge>
+          <h2 className="text-lg font-semibold text-foreground">
+            {port ? "Authorized, but key not delivered" : "API key created"}
+          </h2>
+          <p className="mt-1 mb-4 text-sm text-muted-foreground">
+            {port
+              ? "The plugin didn't respond. Copy the key below and paste it into the key file the plugin opened."
+              : "Copy the key below and paste it into the key file the plugin opened."}
+          </p>
+
+          <div className="flex items-center gap-2 rounded-lg bg-secondary p-3">
+            <code className="flex-1 break-all font-mono text-xs">{createdKey.apiKey}</code>
+            <Button variant="outline" size="sm" className="shrink-0 gap-1.5" onClick={copyKey}>
+              <Copy className="h-3.5 w-3.5" />
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+
+          {port && (
+            <Button
+              variant="outline"
+              className="mt-4 w-full"
+              onClick={retryDelivery}
+              disabled={isRetrying}
+            >
+              {isRetrying && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isRetrying ? "Retrying…" : "Retry delivery"}
+            </Button>
+          )}
+          {retryFailed && (
+            <p className="mt-2 text-center text-xs text-destructive">
+              Still no response from the plugin.
+            </p>
+          )}
+
+          <p className="mt-4 text-xs text-muted-foreground">
+            This key is shown only once, on this screen.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-border bg-card">
+      <CardContent className="p-6">
+        <IconBadge tone="destructive">
+          <XCircle className="h-5 w-5" />
+        </IconBadge>
+        <h2 className="text-lg font-semibold text-foreground">Couldn't authorize the plugin</h2>
+        <p className="mt-1 mb-4 text-sm text-muted-foreground">
+          Please try again in a moment. If the problem persists, you can create a key directly on
+          the API Keys page.
+        </p>
+
+        {errorMessage && (
+          <div className="mb-4 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        )}
+
+        <Button className="w-full" onClick={() => setStep("form")}>
+          Try again
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ConnectPage() {
+  return (
+    <div className="mx-auto max-w-md pt-6 sm:pt-12">
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        }
+      >
+        <ConnectContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/(connect)/layout.tsx
+++ b/app/(connect)/layout.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@/components/portal/header";
+import { PortalProvider, usePortal } from "@/lib/portal-context";
+
+// Focused layout for /connect: portal header without sidebar, search, or status tools
+function ConnectShell({ children }: { children: React.ReactNode }) {
+  const { userProfile, authFailed } = usePortal();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header
+        title="Connect"
+        logo={{
+          src: "https://portal-static.perso.ai/_next/static/media/perso_ai_dubbing.81e52417.webp",
+          alt: "Perso Dubbing",
+        }}
+        authFailed={authFailed}
+        userProfile={userProfile}
+        hideTools
+      />
+      <main className="p-4 sm:p-6">{children}</main>
+    </div>
+  );
+}
+
+export default function ConnectLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <PortalProvider>
+      <ConnectShell>{children}</ConnectShell>
+    </PortalProvider>
+  );
+}

--- a/components/portal/api-endpoint.tsx
+++ b/components/portal/api-endpoint.tsx
@@ -160,14 +160,33 @@ export interface ApiEndpointProps {
   errors?: ErrorResponse[];
 }
 
-function ParameterRow({ param }: { param: Parameter }) {
+function ParameterRow({
+  param,
+  depth = 0,
+}: {
+  param: Parameter;
+  depth?: number;
+}) {
   return (
-    <div className="flex flex-col gap-1 py-3 border-b border-border last:border-b-0">
+    <div
+      className={cn(
+        "flex flex-col gap-1 py-3 border-b border-border last:border-b-0",
+        depth > 0 && "ml-3 border-l border-b-0 pl-3",
+      )}
+    >
       <div className="flex items-center gap-2">
         <code className="text-sm font-semibold text-foreground">
           {param.name}
         </code>
         <span className="text-xs text-muted-foreground">{param.type}</span>
+        {param.deprecated && (
+          <Badge
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 h-4 border-amber-300 text-amber-600"
+          >
+            deprecated
+          </Badge>
+        )}
         {param.required ? (
           <Badge
             variant="outline"
@@ -203,6 +222,13 @@ function ParameterRow({ param }: { param: Parameter }) {
             >
               {v}
             </code>
+          ))}
+        </div>
+      )}
+      {param.fields && param.fields.length > 0 && (
+        <div className="mt-1">
+          {param.fields.map((child) => (
+            <ParameterRow key={child.name} param={child} depth={depth + 1} />
           ))}
         </div>
       )}

--- a/components/portal/header.tsx
+++ b/components/portal/header.tsx
@@ -16,13 +16,17 @@ interface HeaderProps {
   authFailed?: boolean;
   userProfile?: UserProfile | null;
   onMenuClick?: () => void;
+  /** Hide the API Status link and API search */
+  hideTools?: boolean;
+  /** Render a brand logo instead of the text title */
+  logo?: { src: string; alt: string };
 }
 
 function getDisplayName(profile: UserProfile): string {
   return profile.userName || profile.email || "";
 }
 
-export function Header({ title, description, authFailed, userProfile, onMenuClick }: HeaderProps) {
+export function Header({ title, description, authFailed, userProfile, onMenuClick, hideTools, logo }: HeaderProps) {
   const [loginLink, setLoginLink] = useState("");
   const [isLocal, setIsLocal] = useState(false);
   const [token, setToken] = useState("");
@@ -60,26 +64,38 @@ export function Header({ title, description, authFailed, userProfile, onMenuClic
             <Menu className="h-5 w-5" />
           </Button>
         )}
-        <div className="min-w-0">
-          <h1 className="text-lg sm:text-xl font-semibold text-foreground truncate">{title}</h1>
-          {description && (
-            <p className="text-sm text-muted-foreground truncate">{description}</p>
-          )}
-        </div>
+        {logo ? (
+          <img
+            src={logo.src}
+            alt={logo.alt}
+            className="block h-8 w-auto object-contain"
+          />
+        ) : (
+          <div className="min-w-0">
+            <h1 className="text-lg sm:text-xl font-semibold text-foreground truncate">{title}</h1>
+            {description && (
+              <p className="text-sm text-muted-foreground truncate">{description}</p>
+            )}
+          </div>
+        )}
 
       </div>
 
       <div className="flex items-center gap-3 shrink-0">
-        <a
-          href="https://perso-developers.statuspage.io"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <Activity className="h-3.5 w-3.5" />
-          <span className="hidden sm:inline">API Status</span>
-        </a>
-        <ApiSearch />
+        {!hideTools && (
+          <>
+            <a
+              href="https://perso-developers.statuspage.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Activity className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">API Status</span>
+            </a>
+            <ApiSearch />
+          </>
+        )}
         {/* Local profile access token input */}
         {isLocal && (
           <>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -92,7 +92,8 @@ Try it에서 검증한 호출을 그대로 서버 코드에 옮기는 단계입�
 - Base URL: `https://api.perso.ai`
 - 인증: `XP-API-KEY: {YOUR_KEY}` 헤더
 - JSON 요청 시: `Content-Type: application/json`
-- 응답의 `perso-storage://` 경로는 `https://portal-media.perso.ai` 기준으로 해석(필요 시 리졸버 구현)
+- 응답의 `/perso-storage/...` 상대경로는 `https://portal-media.perso.ai`를 앞에 붙여 해석합니다. 경로에 공백·비ASCII가 그대로 포함되므로 URL 인코딩이 필수입니다(필요 시 리졸버 구현).
+- 업로드용 `blobSasUrl` 호스트는 `perso-saas-file-frontdoor.perso.ai`일 수 있으니, 응답 값을 그대로 사용하고 호스트를 하드코딩하지 마세요.
 
 ### 3.1 cURL
 
@@ -102,10 +103,18 @@ curl -X GET "https://api.perso.ai/portal/api/v1/spaces" \
 ```
 
 ```bash
-curl -X POST "https://api.perso.ai/video-translator/api/v1/" \
+curl -X POST "https://api.perso.ai/video-translator/api/v1/projects/spaces/{spaceSeq}/translate" \
      -H "XP-API-KEY: $PERSO_API_KEY" \
      -H "Content-Type: application/json" \
-     -d '{"spaceSeq": 123, "sourceLanguage": "en", "targetLanguage": "ko"}'
+     -d '{
+           "mediaSeq": 12345,
+           "isVideoProject": true,
+           "sourceLanguageCode": "en",
+           "targetLanguages": [{"languageCode": "ko", "ttsModel": "ELEVEN_V3"}],
+           "preferredSpeedType": "GREEN"
+         }'
+# 응답: 200 { "result": { "startGenerateProjectIdList": [101] } }
+# mediaSeq는 파일 업로드 플로우(§5)에서 얻습니다.
 ```
 
 ### 3.2 Node.js (fetch)
@@ -165,6 +174,7 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
 
 - 연동 시작 시점에 "이 호출은 어느 Space 데이터인지"를 명확히 정하고 상수·설정으로 관리하세요.
 - 서버 간 호출일 때도 `spaceSeq`는 **요청 측 책임**입니다.
+- **획득 방법**: `GET /portal/api/v1/spaces`로 조회합니다. 여러 개가 내려오면 `memberRole`(예: `space_owner`)과 `serviceType`(예: `"video_translator"`)을 보고 권한 있는 Space를 고르세요. 권한 없는 Space로 호출하면 `403`이 납니다.
 
 ### 3.5 비동기 작업 (Dubbing, STT, TTS 등)
 
@@ -172,10 +182,12 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
 
 일반적인 패턴:
 
-1. `POST /.../projects` → `projectId` 수신 (상태 `PENDING`)
-2. `GET /.../projects/{projectId}` 폴링 (interval 2~5초, exponential backoff 권장)
-3. 상태가 `COMPLETED`가 되면 결과 리소스 GET
-4. 실패(`FAILED`) 시 에러 본문의 code·message 확인
+1. 번역 요청 → `{"result": {"startGenerateProjectIdList": [...]}}` 수신. 배열이며 **타깃 언어당 1개**의 projectId가 담깁니다. (`PENDING` 같은 상태값은 없습니다.)
+2. `GET /video-translator/api/v1/projects/{projectSeq}/space/{spaceSeq}/progress`로 폴링합니다. `spaceSeq`가 필수이고, 경로 세그먼트는 **단수형 `space`**입니다(복수형 `spaces` 아님, 주의).
+3. 진행 상태는 `status`가 아니라 **`progressReason`** 필드입니다. 값: `Enqueue Pending | Slow Mode Pending | Uploading | Transcribing | Translating | Generating Voice | Analyzing Lip Sync | Applying Lip Sync | Completed | Failed`. `progressReason`이 `"Completed"`가 되면 결과 리소스 GET.
+4. 실패(`"Failed"`) 시 에러 본문의 `code`·`message` 확인.
+
+폴링은 **5초 이상 간격**을 두세요(5초 미만 폴링 금지). 지수 백오프 권장.
 
 폴링은 요청 핸들러 안에서 blocking으로 돌리지 말고 백그라운드 워커·큐(Celery, BullMQ, SQS 등)로 위임하세요.
 
@@ -191,7 +203,9 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
 | `429` | 레이트 리밋    | 백오프 후 재시도, 쿼터 설정 검토                         |
 | `5xx` | 서버 오류      | 재시도(지수 백오프), 지속 발생 시 Request ID와 함께 문의 |
 
-응답 JSON의 `errorCode` / `message`가 1차 디버깅 소스입니다. Usage 로그에서 **Request ID**를 확보해 문의하세요.
+응답 JSON의 `code`(사람이 읽는 `message`와 함께 내려옴)가 1차 디버깅 소스입니다. 기계 판별용으로는 별도의 `detailCode` 필드를 사용하세요(`errorCode`가 아닙니다). Usage 로그에서 **Request ID**를 확보해 문의하세요.
+
+**401 게이트웨이 인증 에러**: 키가 없으면 `{"code":"G0001"}`, 키가 잘못됐거나 만료됐으면 `{"code":"A0010"}`가 내려옵니다. 인증은 게이트웨이에서 먼저 걸리므로, 엔드포인트별 `F4001`류 401은 실제로 보기 어렵습니다.
 
 ---
 
@@ -261,7 +275,7 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
 - **요청이 로그에 안 보임** — API Key 필터가 특정 키로 고정, Time Range 부족, 집계 지연(1~2초) 확인.
 - **시각이 예상과 다름** — 상단 Timezone 토글(`UTC`/`KST`) 확인. 한쪽에서 바꾸면 다른 화면에도 반영됩니다.
 - **키 문자열 재확인 불가** — 설계상 생성 시 1회만 공개. 분실 시 Revoke 후 재발급.
-- **`perso-storage://` 경로가 안 열림** — `https://portal-media.perso.ai` 기준으로 해석해야 합니다. Base URL(`https://api.perso.ai`)과 다릅니다.
+- **`/perso-storage/...` 경로가 안 열림** — 응답은 스킴이 아니라 `/perso-storage/...` **상대경로**입니다. `https://portal-media.perso.ai`를 앞에 붙여 해석해야 합니다(Base URL `https://api.perso.ai`와 다름). 경로에 공백·비ASCII가 그대로 들어오므로 URL 인코딩이 필수입니다.
 - **파일 업로드 — 단일 API 호출이 아님**: Dubbing·STT·Lip Sync 등에 쓸 파일은 `POST /dubbing`에 직접 첨부하는 게 아니라, **별도의 3단계 업로드 플로우**로 먼저 `mediaSeq`를 만들고 그 값을 전달해야 합니다. 가장 자주 놓치는 포인트입니다.
 
   **(A) 직접 업로드 (로컬 파일 → Azure Blob)**
@@ -283,7 +297,8 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
   ```
 
   - (선택) 업로드 전에 `POST /file/api/v1/media/validate`로 용량·해상도·길이·확장자 사전 검증 → 긴 업로드 후 실패하는 사태 방지.
-  - `fileName`은 반드시 URL 인코딩. Step 2의 `fileUrl`에는 쿼리스트링 `?sig=...`를 **제외**한 블랍 URL만 넣습니다.
+  - `fileName`은 반드시 URL 인코딩. Step 3의 `fileUrl`에는 쿼리스트링 `?sig=...`를 제거한 블랍 URL을 넣기를 권장합니다(포함해도 등록은 됨).
+  - Step 1 응답의 `expirationDatetime`은 **타임존 표기 없는 UTC**입니다. 로컬 시간과 직접 비교하지 말고(그러면 이미 만료된 것처럼 보임), 발급 후 30분 안에 업로드하세요.
 
   **(B) 외부 플랫폼 (YouTube / TikTok / Google Drive)**
 
@@ -298,8 +313,8 @@ Perso 플랫폼의 도메인 데이터는 대부분 **Space 단위**로 스코�
 
   **전형적 실패 사례**
   - `POST /video-translator`에 파일을 직접 붙이거나, Step 3을 건너뛴 채 블랍 URL만 전달 → `400 / 404`.
-  - Step 2에 `XP-API-KEY`를 넣음 → Azure가 요청 거부.
-  - Step 2 이후 30분 지연 → SAS 만료 → Step 3에서 업로드된 파일을 찾지 못함.
-  - Step 3의 `fileUrl`에 `?sig=…` 쿼리스트링까지 포함 → 등록 실패.
+  - Step 2에 불필요한 인증 헤더를 넣음 — `XP-API-KEY`는 커스텀 헤더라 Azure가 무시하고 201로 성공하지만, `Authorization` 헤더는 요청을 실패시킬 수 있습니다. **불필요한 인증 헤더는 넣지 마세요(특히 `Authorization`).**
+  - SAS 만료(30분)는 Step 2 업로드에 적용됩니다. 만료 후 PUT은 `403`이므로 Step 1(SAS 재발급)부터 다시 시작하세요.
+  - Step 3의 `fileUrl`에 `?sig=…` 쿼리스트링이 포함돼 있어도 등록은 됩니다. 다만 저장 경로 안정성을 위해 쿼리스트링은 제거하고 전달하기를 권장합니다.
 
   상세 필드·응답 스키마는 사이드바 **API Reference → Media** 참고.

--- a/lib/api-docs-data.ts
+++ b/lib/api-docs-data.ts
@@ -80,7 +80,10 @@ export const spaceCategory: ApiCategory = {
       "seat": 10,
       "isDefaultSpaceOwned": true,
       "memberRole": "space_owner",
-      "useVideoTranslatorEdit": true
+      "useVideoTranslatorEdit": true,
+      "useStudioEdit": false,
+      "serviceType": "video_translator",
+      "originSpaceSeq": 1
     }
   ]
 }`,
@@ -120,7 +123,10 @@ export const spaceCategory: ApiCategory = {
     "seat": 10,
     "isDefaultSpaceOwned": true,
     "memberRole": "space_owner",
-    "useVideoTranslatorEdit": true
+    "useVideoTranslatorEdit": true,
+    "useStudioEdit": false,
+    "serviceType": "video_translator",
+    "originSpaceSeq": 1
   }
 }`,
       },
@@ -188,7 +194,7 @@ export const fileCategory: ApiCategory = {
           step: 3,
           title: "Register Uploaded File",
           description:
-            "Call Upload Video or Upload Audio to register the file. Pass the blob URL (the path portion of blobSasUrl before the '?') as fileUrl.",
+            "Call Upload Video or Upload Audio to register the file. Pass the blobSasUrl as fileUrl. Stripping the query string (the '?...' portion) is recommended — the file still registers with it included, but stripping it keeps the stored path stable.",
           method: "PUT",
           path: "/file/api/upload/video (or /audio)",
           auth: "XP-API-KEY",
@@ -251,7 +257,7 @@ export const fileCategory: ApiCategory = {
       path: "/file/api/upload/video",
       title: "Upload Video",
       description:
-        "Upload a video file via URL. The server downloads the file from the given URL and stores it. Before calling this endpoint, you must first obtain a SAS token via the Get SAS Token endpoint and upload the file to the returned blobSasUrl. Pass the blob URL as the fileUrl parameter. The response includes a seq (media sequence) which is used as mediaSeq when requesting a translation. Note: videoFilePath and thumbnailFilePath in the response are relative paths containing perso-storage. To access the actual file, prepend https://portal-media.perso.ai (e.g. https://portal-media.perso.ai/perso-storage/.../video.mp4).",
+        "Upload a video file via URL. The server downloads the file from the given URL and stores it. Before calling this endpoint, you must first obtain a SAS token via the Get SAS Token endpoint and upload the file to the returned blobSasUrl. Pass the blob URL as the fileUrl parameter. The response includes a seq (media sequence) which is used as mediaSeq when requesting a translation. Note: videoFilePath and thumbnailFilePath in the response are relative paths containing perso-storage. To access the actual file, prepend https://portal-media.perso.ai (e.g. https://portal-media.perso.ai/perso-storage/.../video.mp4). The originalName in the response has its file extension removed (e.g. 'my_video.mp4' becomes 'my_video').",
       requestBody: {
         fields: [
           {
@@ -264,7 +270,8 @@ export const fileCategory: ApiCategory = {
             name: "fileUrl",
             type: "string",
             required: true,
-            description: "Direct access URL of the video file.",
+            description:
+              "Direct access URL of the video file (the blobSasUrl from the SAS token step). Stripping the '?...' query string is recommended for a stable storage path, though it also registers with the query string included.",
           },
           {
             name: "fileName",
@@ -288,7 +295,8 @@ export const fileCategory: ApiCategory = {
   "videoFilePath": "/container/directory/uuid_20260219.mp4",
   "thumbnailFilePath": "/container/directory/uuid_20260219.webp",
   "size": 52428800,
-  "durationMs": 30000
+  "durationMs": 30000,
+  "fastMode": false
 }`,
       },
       errors: [
@@ -312,7 +320,7 @@ export const fileCategory: ApiCategory = {
       path: "/file/api/upload/audio",
       title: "Upload Audio",
       description:
-        "Upload an audio file via URL. The server downloads the file from the given URL and stores it. Before calling this endpoint, you must first obtain a SAS token via the Get SAS Token endpoint and upload the file to the returned blobSasUrl. Pass the blob URL as the fileUrl parameter. The response includes a seq (media sequence) which is used as mediaSeq when requesting a translation. Note: audioFilePath and thumbnailFilePath in the response are relative paths containing perso-storage. To access the actual file, prepend https://portal-media.perso.ai (e.g. https://portal-media.perso.ai/perso-storage/.../audio.mp3).",
+        "Upload an audio file via URL. The server downloads the file from the given URL and stores it. Before calling this endpoint, you must first obtain a SAS token via the Get SAS Token endpoint and upload the file to the returned blobSasUrl. Pass the blob URL as the fileUrl parameter. The response includes a seq (media sequence) which is used as mediaSeq when requesting a translation. Note: audioFilePath and thumbnailFilePath in the response are relative paths containing perso-storage. To access the actual file, prepend https://portal-media.perso.ai (e.g. https://portal-media.perso.ai/perso-storage/.../audio.mp3). The originalName in the response has its file extension removed (e.g. 'my_audio.mp3' becomes 'my_audio').",
       requestBody: {
         fields: [
           {
@@ -325,7 +333,8 @@ export const fileCategory: ApiCategory = {
             name: "fileUrl",
             type: "string",
             required: true,
-            description: "Direct access URL of the audio file.",
+            description:
+              "Direct access URL of the audio file (the blobSasUrl from the SAS token step). Stripping the '?...' query string is recommended for a stable storage path, though it also registers with the query string included.",
           },
           {
             name: "fileName",
@@ -349,7 +358,8 @@ export const fileCategory: ApiCategory = {
   "audioFilePath": "/container/directory/uuid_20260219.mp3",
   "thumbnailFilePath": "audio_thumb.png",
   "size": 5242880,
-  "durationMs": 180000
+  "durationMs": 180000,
+  "fastMode": false
 }`,
       },
       errors: [
@@ -469,7 +479,7 @@ export const fileCategory: ApiCategory = {
       path: "/file/api/upload/sas-token",
       title: "Get SAS Token",
       description:
-        "Issue an Azure Blob Storage SAS token for direct file upload. This is the first step for uploading video or audio files. The token expires 30 minutes after issuance. Upload your file to the returned blobSasUrl via a PUT request before the expiration time, then call the Upload Video or Upload Audio endpoint with the blob URL.",
+        "Issue an Azure Blob Storage SAS token for direct file upload. This is the first step for uploading video or audio files. The token expires 30 minutes after issuance. Upload your file to the returned blobSasUrl via a PUT request before the expiration time, then call the Upload Video or Upload Audio endpoint with the blob URL. Use the blobSasUrl host exactly as returned — do not hardcode it, as it may be perso-saas-file-frontdoor.perso.ai rather than portal-media.perso.ai. Note that expirationDatetime is a naive UTC timestamp with no timezone suffix; do not parse it and compare against local time (that makes it look already expired or near-expiry) — simply upload within 30 minutes of issuance.",
       queryParams: [
         {
           name: "fileName",
@@ -481,7 +491,7 @@ export const fileCategory: ApiCategory = {
       response: {
         statusCode: 200,
         example: `{
-  "blobSasUrl": "https://portal-media.perso.ai/{container}/{path}/uuid.mp4?sv=2024-11-04&se=2026-02-19T13%3A00%3A00Z&sr=b&sp=rw&sig=...",
+  "blobSasUrl": "https://perso-saas-file-frontdoor.perso.ai/perso-storage/{path}/uuid_20260720.mp4?sv=2024-11-04&se=2026-02-19T13%3A00%3A00Z&sr=b&sp=rw&sig=...",
   "expirationDatetime": "2026-02-19T13:00:00"
 }`,
       },
@@ -705,7 +715,20 @@ export const fileCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/download-info",
       title: "Check Download Availability",
       description:
-        "Before downloading files, check which files are currently available for download in your project. Each field returns true/false to indicate availability. Some fields may return null depending on the project type (video vs audio). Use the corresponding download target value for any field that returned true when calling the download endpoint.",
+        "Before downloading files, check which files are currently available for download in your project. Each field returns true/false to indicate availability. Some fields may return null depending on the project type (video vs audio). Use the corresponding download target value for any field that returned true when calling the download endpoint.\n\n" +
+        "Mapping between download-info boolean fields and download target values:\n" +
+        "- hasTranslatedVideo -> target=dubbingVideo\n" +
+        "- hasLipSyncVideo -> target=lipSyncVideo\n" +
+        "- hasOriginalVoiceOnly -> target=originalVoiceAudio (original voice track)\n" +
+        "- hasTranslatedVoice -> target=voiceAudio (translated voice; returns 500 if the project has no translated voice, e.g. Audio Separation projects)\n" +
+        "- hasOriginalBackground / hasTranslatedBackground -> target=backgroundAudio\n" +
+        "- hasOriginalSpeakerAudioCollection -> target=originalVoiceSpeakers\n" +
+        "- hasSpeakerSegmentExcel -> target=speakerSegmentExcel\n" +
+        "- hasSpeakerSegmentWithTranslationExcel -> target=speakerSegmentWithTranslationExcel\n" +
+        "- hasScriptTimestamps -> target=scriptTimestamps\n" +
+        "- hasOriginalSubBackground -> target=originalSubBackground\n" +
+        "- hasZipDownload -> target=all (.tar archive)\n" +
+        "- hasOriginalSubtitle / hasTranslatedSubtitle / hasOriginalSubtitleVtt -> no individual target; SRT/VTT files are only included in the target=all archive",
       pathParams: [
         {
           name: "projectSeq",
@@ -732,12 +755,13 @@ export const fileCategory: ApiCategory = {
   "hasTranslatedVoice": true,
   "hasOriginalBackground": true,
   "hasTranslatedBackground": true,
-  "hasTranslateAudio": null,
-  "hasTranslatedVoiceWithBackground": null,
   "hasZipDownload": true,
   "hasOriginalSpeakerAudioCollection": false,
   "hasSpeakerSegmentExcel": true,
-  "hasSpeakerSegmentWithTranslationExcel": true
+  "hasSpeakerSegmentWithTranslationExcel": true,
+  "hasScriptTimestamps": true,
+  "hasOriginalSubtitleVtt": true,
+  "hasOriginalSubBackground": false
 }`,
       },
     },
@@ -747,7 +771,7 @@ export const fileCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/download",
       title: "Download Files",
       description:
-        "Download project output files. Use the download-info endpoint first to check which files are available, then pass the corresponding target value.",
+        "Download project output files. Use the download-info endpoint first to check which files are available, then pass the corresponding target value. All returned download links are relative paths under /perso-storage/... — prepend https://portal-media.perso.ai to fetch them, and URL-encode the path since it may contain spaces or non-ASCII characters. zippedFileDownloadLink points to a .tar archive.",
       pathParams: [
         {
           name: "projectSeq",
@@ -768,7 +792,7 @@ export const fileCategory: ApiCategory = {
           type: "string",
           required: true,
           description:
-            "The type of file to download. Use the download-info endpoint to check which targets are available.",
+            "The type of file to download. Use the download-info endpoint to check which targets are available. See the download-info endpoint description for the mapping between download-info boolean fields and target values. Matching is case-insensitive (voicewithBackgroundAudio and voiceWithBackgroundAudio both work). An unknown value returns 400 VT4001; a value that is valid in the enum but not present for this project may return 500.",
           enum: [
             "dubbingVideo",
             "lipSyncVideo",
@@ -792,18 +816,19 @@ export const fileCategory: ApiCategory = {
         example: `{
   "result": {
     "videoFile": {
-      "videoDownloadLink": "https://..."
+      "videoDownloadLink": "/perso-storage/.../dubbing_video.mp4"
     },
     "audioFile": {
-      "voiceAudioDownloadLink": "https://...",
-      "backgroundAudioDownloadLink": "https://...",
-      "voiceWithBackgroundAudioDownloadLink": "https://..."
+      "voiceAudioDownloadLink": "/perso-storage/.../voice.wav",
+      "backgroundAudioDownloadLink": "/perso-storage/.../background.wav",
+      "voiceWithBackgroundAudioDownloadLink": "/perso-storage/.../voice_with_background.wav"
     },
     "srtFile": {
-      "originalSubtitleDownloadLink": "https://...",
-      "translatedSubtitleDownloadLink": "https://..."
+      "originalSubtitleDownloadLink": "/perso-storage/.../original.srt",
+      "translatedSubtitleDownloadLink": "/perso-storage/.../translated.srt",
+      "originalSubtitleVttDownloadLink": "/perso-storage/.../original.vtt"
     },
-    "zippedFileDownloadLink": "https://..."
+    "zippedFileDownloadLink": "/perso-storage/.../export.tar"
   }
 }`,
       },
@@ -837,7 +862,7 @@ export const dubbingCategory: ApiCategory = {
           step: 2,
           title: "Initialize Queue",
           description:
-            "Call the Usage API's Get User Queue endpoint to ensure the space has a translation queue. Without this, the first translation request in a new space will fail with 'space queue not found'.",
+            "Call the Usage API's Get User Queue endpoint to ensure the space has a translation queue. Despite being named 'Get User Queue', calling it with PUT creates/initializes the queue. Without this, the first translation request in a new space will fail with 'space queue not found'.",
           method: "PUT",
           path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/queue",
           auth: "XP-API-KEY",
@@ -868,9 +893,9 @@ export const dubbingCategory: ApiCategory = {
           description:
             "Once complete, download the output files. Use the download-info endpoint first to check available file types.",
           method: "GET",
-          path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/download?target=video",
+          path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/download?target=dubbingVideo",
           auth: "XP-API-KEY",
-          note: "Available targets: video, dubbingVideo, lipSyncVideo, originalSubtitle, translatedSubtitle, voiceAudio, backgroundAudio, all, etc.",
+          note: "Working target values: dubbingVideo, lipSyncVideo, voiceAudio, originalVoiceAudio, backgroundAudio, voicewithBackgroundAudio, originalVoiceSpeakers, speakerSegmentExcel, speakerSegmentWithTranslationExcel, scriptTimestamps, originalSubBackground, audioScript, all. Subtitles (SRT) cannot be fetched as an individual target — they are only delivered inside the target=all archive (.tar). Requesting a file that download-info reports as false may return 500 rather than a 4xx.",
         },
       ],
     },
@@ -945,9 +970,14 @@ export const dubbingCategory: ApiCategory = {
                 name: "ttsModel",
                 type: "string",
                 required: false,
-                enum: ["ELEVEN_V2", "ELEVEN_V3"],
+                enum: ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"],
                 description:
-                  "TTS model to apply to this language. Required for DUBBING / LIPSYNC requests. " +
+                  "TTS model to apply to this language. Optional even for DUBBING / LIPSYNC — " +
+                  "if omitted, the server applies a default model supported by the language. " +
+                  "The specific default is not documented, so specify `ttsModel` explicitly if you need deterministic behavior. " +
+                  "If specified, it must be one of the target language's supportedTtsModels " +
+                  "or the request fails with 400 VT4009 (UNSUPPORTED_LANGUAGE_TTS_MODEL_PAIR). " +
+                  "Check the Language API's supportedTtsModels for the target language before specifying. " +
                   "Ignored for STT / AudioSeparation requests (may be omitted).",
               },
             ],
@@ -993,8 +1023,9 @@ export const dubbingCategory: ApiCategory = {
             description:
               "(Deprecated since 2026-05-14) Single TTS model applied to all target languages. " +
               "New integrations should specify `ttsModel` per language inside `targetLanguages`. " +
-              "ELEVEN_V2 (natural) or ELEVEN_V3 (emotional).",
-            enum: ["ELEVEN_V2", "ELEVEN_V3"],
+              "AUDIO_ENGINE_V3 (all languages), ELEVEN_V2 (natural), or ELEVEN_V3 (emotional). " +
+              "Each value must be in the target language's supportedTtsModels (see the Language API).",
+            enum: ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"],
           },
           {
             name: "title",
@@ -1010,7 +1041,7 @@ export const dubbingCategory: ApiCategory = {
   "sourceLanguageCode": "en",
   "targetLanguages": [
       { "languageCode": "ko", "ttsModel": "ELEVEN_V3" },
-      { "languageCode": "ja", "ttsModel": "ELEVEN_V2" }
+      { "languageCode": "ja", "ttsModel": "ELEVEN_V3" }
   ],
   "numberOfSpeakers": 2,
   "withLipSync": false,
@@ -1019,7 +1050,7 @@ export const dubbingCategory: ApiCategory = {
 }`,
       },
       response: {
-        statusCode: 201,
+        statusCode: 200,
         example: `{
   "result": {
     "startGenerateProjectIdList": [101, 102]
@@ -1078,6 +1109,7 @@ export const dubbingCategory: ApiCategory = {
   "seq": 101,
   "projectType": "VIDEO",
   "title": "My Translation Project",
+  "userName": "oh****on",
   "isEditable": true,
   "durationMs": 120000,
   "sourceLanguage": {
@@ -1091,9 +1123,12 @@ export const dubbingCategory: ApiCategory = {
   "progress": 100,
   "progressReason": "Completed",
   "hasFailed": false,
+  "failureReason": null,
   "isLipSync": false,
   "isLinkShared": false,
   "projectGenerationType": "DUBBING",
+  "usedFeature": [],
+  "experimentList": [],
   "thumbnailUrl": "https://...",
   "createDate": "2026-01-15T10:30:00Z",
   "updateDate": "2026-01-15T11:00:00Z"
@@ -1211,7 +1246,7 @@ export const dubbingCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/script",
       title: "Get Script",
       description:
-        "Retrieve the project script with sentence-level translations, matching rates, and speaker information.",
+        "Retrieve the project script with sentence-level translations, matching rates, and speaker information. matchingRate and rewrite can be null for a given sentence. Each speaker exposes a projectSpeakerSeq, which is the value required by the Temp Save Draft endpoint.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1246,16 +1281,20 @@ export const dubbingCategory: ApiCategory = {
         statusCode: 200,
         example: `{
   "hasNext": false,
+  "nextCursorId": null,
   "retranslateAvailable": true,
   "sentences": [
     {
       "seq": 1,
+      "externalScriptSeq": "pvtv-e1045225d769af98305367b722c1adfb",
       "speakerOrderIndex": 0,
       "offsetMs": 0,
       "durationMs": 3500,
+      "originalDraftText": "Hello, welcome.",
       "originalText": "Hello, welcome.",
       "translatedText": "...",
-      "audioUrl": "https://...",
+      "proofRead": false,
+      "audioUrl": "/perso-storage/.../audio.mp3",
       "matchingRate": {
         "level": 3,
         "levelType": "GOOD"
@@ -1269,7 +1308,9 @@ export const dubbingCategory: ApiCategory = {
   "speakers": [
     {
       "speakerOrderIndex": 0,
-      "externalSpeakerSeq": "spk_001"
+      "externalSpeakerSeq": "spk_001",
+      "projectSpeakerSeq": 12345,
+      "voiceId": "pvsp-1351dafa5135"
     }
   ]
 }`,
@@ -1304,6 +1345,8 @@ export const dubbingCategory: ApiCategory = {
     "progress": 65,
     "progressReason": "Transcribing",
     "hasFailed": false,
+    "failureReason": null,
+    "engineErrorMessage": null,
     "speedType": "fast",
     "expectedRemainingTimeMinutes": 3,
     "isCancelable": true
@@ -1317,7 +1360,7 @@ export const dubbingCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/cancel",
       title: "Cancel Project",
       description:
-        "Cancel a pending project. Only available for GREEN zone projects in PENDING initial export state.",
+        "Cancel a pending project. Only available for GREEN zone projects in PENDING initial export state. Cancellation only works while the project is still queued (pending); when the GREEN queue is empty, processing starts immediately, so a 400 VT4004 (cancellation not allowed) is common even right after creation.",
       pathParams: [
         {
           name: "projectSeq",
@@ -1782,21 +1825,22 @@ export const editingCategory: ApiCategory = {
             description: "The draft original text to temporarily save.",
           },
           {
-            name: "speakerSeq",
-            type: "string",
+            name: "projectSpeakerSeq",
+            type: "integer",
             required: true,
-            description: "The speaker identifier to temporarily assign.",
+            description:
+              "The speaker identifier to temporarily assign. Required for project version 2 speaker changes. Obtain it from the speakers[].projectSpeakerSeq field of the Get Script response.",
           },
         ],
         example: `{
   "originalDraftText": "Draft translation text",
-  "speakerSeq": "spk_001"
+  "projectSpeakerSeq": 12345
 }`,
       },
       response: {
         statusCode: 200,
         example: `{
-  "result": {}
+  "result": null
 }`,
       },
     },
@@ -1946,9 +1990,7 @@ export const editingCategory: ApiCategory = {
       },
       response: {
         statusCode: 200,
-        example: `{
-  "result": {}
-}`,
+        example: `// Empty response body`,
       },
     },
     {
@@ -1982,9 +2024,7 @@ export const editingCategory: ApiCategory = {
       ],
       response: {
         statusCode: 200,
-        example: `{
-  "result": {}
-}`,
+        example: `// Empty response body`,
       },
       errors: [
         {
@@ -2078,7 +2118,7 @@ export const usageCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/media/quota",
       title: "Estimate Quota Usage",
       description:
-        "Calculate the estimated quota that will be consumed for a given media file based on its type, duration, and translation settings.",
+        "Calculate the estimated quota that will be consumed for a given media file based on its type, duration, and translation settings. Quota is measured in seconds of media (a 9-second clip costs 9); enabling lipSync doubles it (a 9-second clip costs 18). width and height are required for both video and audio requests — omitting them returns a 500.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -2110,13 +2150,13 @@ export const usageCategory: ApiCategory = {
         {
           name: "width",
           type: "integer",
-          required: false,
+          required: true,
           description: "Video width in pixels.",
         },
         {
           name: "height",
           type: "integer",
-          required: false,
+          required: true,
           description: "Video height in pixels.",
         },
         {
@@ -2131,7 +2171,8 @@ export const usageCategory: ApiCategory = {
         statusCode: 200,
         example: `{
   "result": {
-    "expectedUsedQuota": 5000
+    "expectedUsedQuota": 10.0,
+    "promotionExpectedUsedQuota": 10.0
   }
 }`,
       },
@@ -2142,7 +2183,7 @@ export const usageCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/queue",
       title: "Get User Queue",
       description:
-        "Retrieve or initialize the queue for a user within a space. If no queue exists, a new one is automatically created and returned. This endpoint must be called before requesting a translation if the space does not yet have an initialized queue — otherwise the translation request will fail with a 'space queue not found' error. Both GET and PUT methods are supported. Internally, the service fetches the user's plan options from the Credit service, retrieves quota information, and looks up the TranslateQueue — creating a new one if it does not exist.",
+        "Despite the name, calling this with PUT initializes (creates) the queue if it does not exist. Retrieve or initialize the queue for a user within a space. If no queue exists, a new one is automatically created and returned. This endpoint must be called before requesting a translation if the space does not yet have an initialized queue — otherwise the translation request will fail with a 'space queue not found' error. Both GET and PUT methods are supported. Internally, the service fetches the user's plan options from the Credit service, retrieves quota information, and looks up the TranslateQueue — creating a new one if it does not exist.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -2154,12 +2195,11 @@ export const usageCategory: ApiCategory = {
       response: {
         statusCode: 200,
         example: `{
-  "success": true,
-  "data": {
-    "userSeq": 12345,
-    "planName": "Free",
-    "usedQueueCount": 5,
-    "maxQueueCount": 10,
+  "result": {
+    "userSeq": 19507,
+    "planName": "pro",
+    "usedQueueCount": 0,
+    "maxQueueCount": 3,
     "redZoneQueueCount": 0
   }
 }`,
@@ -2310,25 +2350,38 @@ export const languageCategory: ApiCategory = {
       path: "/video-translator/api/v1/languages",
       title: "List Languages",
       description:
-        "Returns a list of all supported languages including their language codes and names. Experimental languages are flagged accordingly.",
+        "Returns a list of all supported languages including their language codes, names, and the TTS models each language supports. This endpoint is the only way to check TTS model support — there is no dedicated model-lookup endpoint. `supportedTtsModels` lists the valid TTS models when the language is used as a translation target; use it to validate `ttsModel` before submitting a translation (an unsupported pair returns 400 VT4009). The same `code` can appear multiple times, distinguished by `languageTag` (e.g. English (US) has `languageTag: \"default\"` while English (UK) has `languageTag: \"en-GB\"`; likewise pt-PT, es-ES). `code: \"auto\"` (Auto Detect) is for `sourceLanguageCode` only — it has an empty `supportedTtsModels` and cannot be a target. Experimental languages are flagged via `experiment`.",
       response: {
         statusCode: 200,
         example: `{
   "languages": [
     {
-      "code": "en",
-      "name": "English",
-      "experiment": false
+      "code": "auto",
+      "name": "Auto Detect",
+      "languageTag": "default",
+      "experiment": false,
+      "supportedTtsModels": []
     },
     {
-      "code": "ko",
-      "name": "Korean",
-      "experiment": false
+      "code": "en",
+      "name": "English (US)",
+      "languageTag": "default",
+      "experiment": false,
+      "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"]
+    },
+    {
+      "code": "en",
+      "name": "English (UK)",
+      "languageTag": "en-GB",
+      "experiment": false,
+      "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V3"]
     },
     {
       "code": "ja",
       "name": "Japanese",
-      "experiment": true
+      "languageTag": "default",
+      "experiment": false,
+      "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V3"]
     }
   ]
 }`,
@@ -2435,7 +2488,7 @@ export const communitySpotlightCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/recommended",
       title: "List Featured Projects",
       description:
-        "Retrieve a paginated list of projects featured in the Community Spotlight.",
+        "Retrieve a paginated list of projects featured in the Community Spotlight. This is a public endpoint — no XP-API-KEY is required.",
       queryParams: [
         {
           name: "page",
@@ -2454,7 +2507,7 @@ export const communitySpotlightCategory: ApiCategory = {
           name: "languageCode",
           type: "string",
           required: false,
-          description: "Filter by target language code (e.g. ko, en, ja).",
+          description: "Filter by source language code (e.g. ko, en, ja).",
         },
       ],
       response: {
@@ -2497,7 +2550,7 @@ export const communitySpotlightCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/recommended/{projectSeq}",
       title: "Get Featured Project",
       description:
-        "Retrieve detailed information about a specific featured project.",
+        "Retrieve detailed information about a specific featured project. This is a public endpoint — no XP-API-KEY is required. The response is not wrapped in a result object. File URLs are relative /perso-storage/... paths (prepend https://portal-media.perso.ai).",
       pathParams: [
         {
           name: "projectSeq",
@@ -2509,29 +2562,37 @@ export const communitySpotlightCategory: ApiCategory = {
       response: {
         statusCode: 200,
         example: `{
-  "result": {
-    "seq": 1,
-    "title": "How to build with Framer",
-    "mediaType": "VIDEO",
-    "userName": "oh****on",
-    "durationMs": 10000,
-    "sourceLanguage": {
-      "code": "en",
-      "name": "English"
-    },
-    "targetLanguage": {
-      "code": "ko",
-      "name": "Korean"
-    },
-    "originalFileUrl": "/original.mp4",
-    "translatedFileUrl": "/translated.mp4",
-    "lipSyncFileUrl": "/lip-sync.mp4",
-    "isLipSync": true,
-    "feedbackAverage": {
-      "averageRating": 4.5,
-      "count": 10
-    }
-  }
+  "seq": 1,
+  "title": "How to build with Framer",
+  "mediaType": "VIDEO",
+  "userName": "oh****on",
+  "thumbnailUrl": "/thumbnail.jpg",
+  "durationMs": 10000,
+  "sourceLanguage": {
+    "code": "en",
+    "name": "English (US)",
+    "languageTag": "default",
+    "experiment": false,
+    "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"]
+  },
+  "targetLanguage": {
+    "code": "ko",
+    "name": "Korean",
+    "languageTag": "default",
+    "experiment": false,
+    "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"]
+  },
+  "originalFileUrl": "/original.mp4",
+  "translatedFileUrl": "/translated.mp4",
+  "lipSyncFileUrl": "/lip-sync.mp4",
+  "subtitleFileUrl": "/subtitle.srt",
+  "isLipSync": true,
+  "feedbackAverage": {
+    "averageRating": 4.5,
+    "count": 10
+  },
+  "createDate": "2026-01-15T10:00:00Z",
+  "updateDate": "2026-01-15T11:00:00Z"
 }`,
       },
       errors: [
@@ -2544,7 +2605,7 @@ export const communitySpotlightCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/shared/{sharedQuery}",
       title: "Get Shared Project",
       description:
-        "Retrieve project information using an encrypted share query string.",
+        "Retrieve project information using an encrypted share query string. This is a public endpoint — no XP-API-KEY is required. The response is not wrapped in a result object. File URLs are relative /perso-storage/... paths (prepend https://portal-media.perso.ai).",
       pathParams: [
         {
           name: "sharedQuery",
@@ -2556,26 +2617,38 @@ export const communitySpotlightCategory: ApiCategory = {
       response: {
         statusCode: 200,
         example: `{
-  "result": {
-    "seq": 1,
-    "title": "How to build with Framer",
-    "projectType": "VIDEO",
-    "userName": "oh****on",
-    "durationMs": 10000,
-    "sourceLanguage": {
-      "code": "en",
-      "name": "English"
-    },
-    "targetLanguage": {
-      "code": "ko",
-      "name": "Korean"
-    },
-    "originalFileUrl": "/original.mp4",
-    "translatedFileUrl": "/translated.mp4",
-    "isLipSync": true
-  }
+  "seq": 1,
+  "title": "How to build with Framer",
+  "projectType": "VIDEO",
+  "userName": "oh****on",
+  "durationMs": 10000,
+  "sourceLanguage": {
+    "code": "en",
+    "name": "English (US)",
+    "languageTag": "default",
+    "experiment": false,
+    "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"]
+  },
+  "targetLanguage": {
+    "code": "ko",
+    "name": "Korean",
+    "languageTag": "default",
+    "experiment": false,
+    "supportedTtsModels": ["AUDIO_ENGINE_V3", "ELEVEN_V2", "ELEVEN_V3"]
+  },
+  "originalFileUrl": "/original.mp4",
+  "translatedFileUrl": "/translated.mp4",
+  "isLipSync": true
 }`,
       },
+      errors: [
+        {
+          code: "VT4035",
+          status: 403,
+          description:
+            "Sharing is disabled for this project (SHARED_NOT_ACCESSIBLE)",
+        },
+      ],
     },
   ],
 };
@@ -2595,7 +2668,8 @@ export const sttCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/stt",
       title: "Create STT Project",
       description:
-        "Create a Speech-to-Text (STT) project from an uploaded media file. The mediaSeq is the seq value returned from the Upload Video or Upload Audio endpoint in the File API.",
+        "Create a Speech-to-Text (STT) project from an uploaded media file. The mediaSeq is the seq value returned from the Upload Video or Upload Audio endpoint in the File API. " +
+        "If you receive a 'space queue not found' error, first call PUT /video-translator/api/v1/projects/spaces/{spaceSeq}/queue (Usage API) to initialize the queue, then retry.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -2635,7 +2709,7 @@ export const sttCategory: ApiCategory = {
 }`,
       },
       response: {
-        statusCode: 201,
+        statusCode: 200,
         example: `{
   "result": {
     "startGenerateProjectIdList": [101]
@@ -2677,7 +2751,7 @@ export const sttCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/stt/script",
       title: "Get STT Project Script",
       description:
-        "Retrieve the script for a completed STT project. Uses cursor-based pagination — omit cursorId on the first request.",
+        "Retrieve the script for a completed STT project. Uses cursor-based pagination — omit cursorId on the first request. Each sentence's originalDraftText may be null; use originalText for the transcribed content. Each speaker's voiceId carries the same pvtv- identifier as externalSpeakerSeq.",
       pathParams: [
         {
           name: "projectSeq",
@@ -2720,14 +2794,17 @@ export const sttCategory: ApiCategory = {
       "speakerOrderIndex": 1,
       "offsetMs": 0,
       "durationMs": 1000,
-      "originalDraftText": "Hello, world!",
+      "originalDraftText": null,
       "originalText": "Hello, world!"
     }
   ],
   "speakers": [
     {
       "speakerOrderIndex": 1,
-      "externalSpeakerSeq": "pvtv-e1045225d769af98305367b722c1adfb"
+      "externalSpeakerSeq": "pvtv-e1045225d769af98305367b722c1adfb",
+      "voiceId": "pvtv-e1045225d769af98305367b722c1adfb",
+      "speakerSeq": 1,
+      "speakerName": "Speaker 1"
     }
   ]
 }`,
@@ -2751,7 +2828,8 @@ export const audioSeparationCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/spaces/{spaceSeq}/audio-separation",
       title: "Create Audio Separation Project",
       description:
-        "Create an Audio Separation project that splits a media file into voice and background audio tracks.",
+        "Create an Audio Separation project that splits a media file into voice and background audio tracks. " +
+        "If you receive a 'space queue not found' error, first call PUT /video-translator/api/v1/projects/spaces/{spaceSeq}/queue (Usage API) to initialize the queue, then retry.",
       pathParams: [
         {
           name: "spaceSeq",
@@ -2791,7 +2869,7 @@ export const audioSeparationCategory: ApiCategory = {
 }`,
       },
       response: {
-        statusCode: 201,
+        statusCode: 200,
         example: `{
   "result": {
     "startGenerateProjectIdList": [102]
@@ -2805,7 +2883,7 @@ export const audioSeparationCategory: ApiCategory = {
       path: "/video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/audio-separation/script",
       title: "Get Audio Separation Project Script",
       description:
-        "Retrieve the script for a completed Audio Separation project. Uses cursor-based pagination — omit cursorId on the first request.",
+        "Retrieve the script for a completed Audio Separation project. Uses cursor-based pagination — omit cursorId on the first request. Each sentence's originalDraftText may be null; use originalText for the transcribed content. Each speaker's voiceId carries the same pvtv- identifier as externalSpeakerSeq.",
       pathParams: [
         {
           name: "projectSeq",
@@ -2848,7 +2926,7 @@ export const audioSeparationCategory: ApiCategory = {
       "speakerOrderIndex": 1,
       "offsetMs": 0,
       "durationMs": 1000,
-      "originalDraftText": "Hello, world!",
+      "originalDraftText": null,
       "originalText": "Hello, world!",
       "audioUrl": "/perso-storage/audio.mp3"
     }
@@ -2856,7 +2934,10 @@ export const audioSeparationCategory: ApiCategory = {
   "speakers": [
     {
       "speakerOrderIndex": 1,
-      "externalSpeakerSeq": "pvtv-e1045225d769af98305367b722c1adfb"
+      "externalSpeakerSeq": "pvtv-e1045225d769af98305367b722c1adfb",
+      "voiceId": "pvtv-e1045225d769af98305367b722c1adfb",
+      "speakerSeq": 1,
+      "speakerName": "Speaker 1"
     }
   ]
 }`,

--- a/lib/llm-docs.ts
+++ b/lib/llm-docs.ts
@@ -4,7 +4,7 @@ import {
   type ApiCategory,
   type ApiGuide,
 } from "@/lib/api-docs-data";
-import type { ApiEndpointProps } from "@/components/portal/api-endpoint";
+import type { ApiEndpointProps, Parameter } from "@/components/portal/api-endpoint";
 
 function renderGuide(guide: ApiGuide): string {
   const lines: string[] = [];
@@ -43,6 +43,22 @@ function renderGuide(guide: ApiGuide): string {
   return lines.join("\n");
 }
 
+function renderParamLines(p: Parameter, indent: number): string[] {
+  const pad = "  ".repeat(indent);
+  let desc = `${pad}- ${p.name} (${p.type}, ${p.required ? "required" : "optional"})`;
+  if (p.deprecated) desc += " (deprecated)";
+  desc += `: ${p.description}`;
+  if (p.default) desc += ` (default: ${p.default})`;
+  if (p.enum) desc += ` [${p.enum.join(", ")}]`;
+  const out = [desc];
+  if (p.fields?.length) {
+    for (const child of p.fields) {
+      out.push(...renderParamLines(child, indent + 1));
+    }
+  }
+  return out;
+}
+
 function renderEndpoint(ep: ApiEndpointProps): string {
   const lines: string[] = [];
   lines.push(`### ${ep.method} ${ep.path}`);
@@ -53,9 +69,7 @@ function renderEndpoint(ep: ApiEndpointProps): string {
   if (ep.pathParams?.length) {
     lines.push("Path parameters:");
     for (const p of ep.pathParams) {
-      lines.push(
-        `  - ${p.name} (${p.type}, ${p.required ? "required" : "optional"}): ${p.description}`,
-      );
+      lines.push(...renderParamLines(p, 1));
     }
     lines.push("");
   }
@@ -63,10 +77,7 @@ function renderEndpoint(ep: ApiEndpointProps): string {
   if (ep.queryParams?.length) {
     lines.push("Query parameters:");
     for (const p of ep.queryParams) {
-      let desc = `  - ${p.name} (${p.type}, ${p.required ? "required" : "optional"}): ${p.description}`;
-      if (p.default) desc += ` (default: ${p.default})`;
-      if (p.enum) desc += ` [${p.enum.join(", ")}]`;
-      lines.push(desc);
+      lines.push(...renderParamLines(p, 1));
     }
     lines.push("");
   }
@@ -74,10 +85,7 @@ function renderEndpoint(ep: ApiEndpointProps): string {
   if (ep.requestBody) {
     lines.push("Request body:");
     for (const f of ep.requestBody.fields) {
-      let desc = `  - ${f.name} (${f.type}, ${f.required ? "required" : "optional"}): ${f.description}`;
-      if (f.default) desc += ` (default: ${f.default})`;
-      if (f.enum) desc += ` [${f.enum.join(", ")}]`;
-      lines.push(desc);
+      lines.push(...renderParamLines(f, 1));
     }
     lines.push("");
     lines.push("Request example:");
@@ -132,12 +140,16 @@ const CRITICAL_RULES = `## CRITICAL RULES (read before writing any code)
 These are the most common failure points. Apply them by default.
 
 1. **Authentication header is \`XP-API-KEY\`, not \`Authorization: Bearer\`.**
-   - Every request to ${apiDocsConfig.apiBaseUrl} must include \`XP-API-KEY: <your-key>\`.
+   - Every request to ${apiDocsConfig.apiBaseUrl} must include \`XP-API-KEY: <your-key>\`, except a few public community endpoints (Community Spotlight: List/Get Featured Projects and Get Shared Project) which need no auth.
    - Bearer JWT is never used for this API.
 
 2. **Multi-tenancy via \`spaceSeq\`.**
    - Most domain endpoints require a \`spaceSeq\` (Space ID) in the request body or query.
    - Missing \`spaceSeq\` is the #1 cause of empty lists or 404s — when in doubt, pass it explicitly.
+   - Obtain \`spaceSeq\` from \`GET /portal/api/v1/spaces\` (the Space API).
+   - If several spaces are returned, pick one you have permission for: check \`memberRole\`
+     (e.g. \`space_owner\`) and \`serviceType\` (dubbing work uses \`"video_translator"\`).
+     Using a space you lack permission on returns 403.
 
 3. **File upload is a 3-step flow, not a single call.**
    Do NOT try to attach binary files to Dubbing/STT/Lip-Sync requests directly. First produce a \`mediaSeq\`:
@@ -147,22 +159,37 @@ These are the most common failure points. Apply them by default.
    Step 2:  PUT  {blobSasUrl}              (direct to Azure Blob, NOT ${apiDocsConfig.apiBaseUrl})
                 Headers: x-ms-blob-type: BlockBlob
                 Body: raw file bytes
-                DO NOT send XP-API-KEY on this request.
+                Use the blobSasUrl exactly as returned. Do NOT hardcode the host — it may be
+                perso-saas-file-frontdoor.perso.ai rather than portal-media.perso.ai.
+                No XP-API-KEY is needed here (the SAS signature is the auth); if sent it is ignored.
                 201 on success. 403 = SAS expired, go back to Step 1.
    Step 3:  PUT /file/api/upload/video   (or /audio)
-                Body: { "fileUrl": "<blobSasUrl with the '?...' query string stripped>", ... }
+                Body: { "fileUrl": "<blobSasUrl>", ... }
                 -> { "seq": <number> }    // use this as mediaSeq in downstream APIs
+                Stripping the '?...' query string from fileUrl is recommended (the file still
+                registers with it, but strip it for stable storage paths).
    \`\`\`
    For YouTube/TikTok/Drive URLs, use the External flow instead: \`external/metadata\` → \`media/validate\` → \`upload/video/external\`.
 
-4. **Long-running jobs return an ID — poll it.**
-   - Dubbing, STT, Lip-Sync, TTS create a project and return immediately with a \`projectId\` (status \`PENDING\`).
-   - Poll \`GET /.../projects/{projectId}\` every 2–5 seconds (exponential backoff recommended) until status is \`COMPLETED\` or \`FAILED\`.
+4. **Long-running jobs return generated project IDs — poll them.**
+   - Dubbing, STT, Audio Separation, Lip-Sync create projects and return immediately with
+     \`{ "result": { "startGenerateProjectIdList": [101] } }\`. There can be more than one ID
+     (one per target language) — poll each.
+   - Poll \`GET /video-translator/api/v1/projects/{projectSeq}/space/{spaceSeq}/progress\`
+     (note the singular \`space\`; \`spaceSeq\` is required) at intervals of at least 5 seconds.
+   - Status lives in \`progressReason\`, not \`status\`. Values:
+     \`Enqueue Pending | Slow Mode Pending | Uploading | Transcribing | Translating |
+     Generating Voice | Analyzing Lip Sync | Applying Lip Sync | Completed | Failed\`.
+     Done when \`progressReason === "Completed"\`; failed when \`"Failed"\` (see \`hasFailed\`).
+   - Treat \`expectedRemainingTimeMinutes\` as a rough hint only — it can go negative after completion.
    - Never block an HTTP handler on the polling loop — use a background worker/queue.
 
 5. **Response file paths resolve against \`${apiDocsConfig.storageBaseUrl}\`, not the API base.**
-   - Fields like \`videoFilePath\`, \`audioFilePath\`, \`thumbnailFilePath\` contain relative paths under \`/perso-storage/...\`.
+   - Fields like \`videoFilePath\`, \`audioFilePath\`, \`thumbnailFilePath\`, download links, \`audioUrl\`,
+     and \`thumbnailUrl\` contain relative paths under \`/perso-storage/...\`.
    - Prepend \`${apiDocsConfig.storageBaseUrl}\` (not \`${apiDocsConfig.apiBaseUrl}\`) to download the file.
+   - These paths can contain spaces and non-ASCII characters verbatim, so URL-encode the path
+     when fetching — an unencoded path fails.
 
 6. **HTTP error codes follow a predictable map.**
    - 401 = \`XP-API-KEY\` header missing, misspelled, or key is Expired/Revoked.
@@ -170,6 +197,15 @@ These are the most common failure points. Apply them by default.
    - 404 = usually \`spaceSeq\` or resource ID wrong. Verify the IDs before assuming the endpoint is broken.
    - 429 = rate limited. Back off exponentially.
    - 5xx = retry with backoff; include the Request ID from Usage logs when escalating.
+
+   Error response bodies come in a few distinct shapes — parse defensively:
+   - Gateway auth errors (handled before routing, so per-endpoint 401s are rarely seen directly):
+     missing key \`{"code":"G0001","message":"...","status":"UNAUTHORIZED"}\`;
+     invalid/expired key \`{"code":"A0010","message":"...","status":"UNAUTHORIZED"}\`.
+   - Domain errors: \`{"code":"VT4009","detailCode":"UNSUPPORTED_LANGUAGE_TTS_MODEL_PAIR","message":"...","status":"BAD_REQUEST"}\`.
+     The machine-readable field is \`code\` (not \`errorCode\`); \`detailCode\` disambiguates the reason.
+   - Missing required parameter (RFC 7807): \`{"type":"about:blank","title":"Bad Request","status":400,"detail":"Required parameter 'memberRole' is not present.",...}\`.
+   - Some server errors return the raw Spring shape: \`{"timestamp":"...","status":500,"error":"...","path":"..."}\`.
 
 7. **\`fileName\` for SAS token must be URL-encoded.** Spaces, Korean/Japanese characters, parentheses all need encoding.
 


### PR DESCRIPTION
## Release Scope

develop → main. The only change included is #18 (docs: fix API reference inaccuracies found by live API verification).

## Background

Every part of the API documentation (llm.txt, portal API Reference, and the getting-started guide) was verified against the production API (api.perso.ai) with real calls. Several spots where following the docs verbatim leads to failures were found and corrected based on measured behavior.

## Key Changes

**Things that failed when following the docs (verified live)**
- The translate example `ja + ELEVEN_V2` actually returns `400 VT4009` — replaced with a valid pair and added `AUDIO_ENGINE_V3` to the `ttsModel` enums
- Documented `supportedTtsModels` / `languageTag` on the Language API (the sole source for per-language TTS model support)
- The download guide's `target=video` / `originalSubtitle` / `translatedSubtitle` cause a 500 — replaced with the actually working target values and added a download-info ↔ target mapping table
- Documented the real error formats: gateway `G0001`/`A0010`, domain `code`/`detailCode`, RFC-7807

**Spec alignment**
- 14 measured mismatches fixed: creation status codes 201→200, queue/featured/shared response wrappers, temp-save `projectSpeakerSeq`, quota estimation width/height being required, etc.
- Clarified that file paths are relative `/perso-storage/...` paths (prepend portal-media + URL-encode)
- Softened claims contradicted by measurements (XP-API-KEY on blob upload, fileUrl query string, etc.)

**Rendering**
- Nested request-body fields (`languageCode` / `ttsModel` under `targetLanguages`) were previously dropped from both llm.txt and the portal docs — now rendered, with a deprecated badge

**getting-started.md**
- Replaced the non-existent `POST /video-translator/api/v1/` example with the real translate endpoint, fixed `errorCode` → `code`/`detailCode`, corrected the `perso-storage://` scheme notation, aligned the async polling flow with reality, and added missing guidance (how to obtain spaceSeq, SAS timestamp is UTC)

## Pre-release Verification (side-effect check complete)

- Production build passes (all 13 docs pages prerender statically)
- Endpoint ids/paths/methods unchanged → no impact on anchor deep links or the search index
- All 16 Try-it request examples validated as parseable JSON; dialog behavior confirmed
- `/llms.txt` (the AI-agent URL advertised on the home page) rewrite serves the updated content
- A zero-context agent completed the dubbing (en→ja), STT, and audio-separation workflows end-to-end using only the updated llm.txt
- No new tsc errors (the 2 pre-existing errors in api-try-it.tsx also exist on main)

Once deployed, `developers.perso.ai/llms.txt` is updated immediately.